### PR TITLE
Put blockquote margin right and left to 0px

### DIFF
--- a/style.css
+++ b/style.css
@@ -83,6 +83,8 @@ blockquote {
   font-style: italic;
   font-size: 16pt;
   background-color: #222224;
+  margin-left: 0;
+  margin-right: 0;
 }
 #assinatura {
   font-family: "Dancing Script", cursive;


### PR DESCRIPTION
Hi,
Its my second PR :) 
I put the blockquote margin right and left to 0px. Like this the blockquote is a the same size of the rest of the body. 
Thanks
